### PR TITLE
Add specific uses of absolute/tilde path mod res and simplify normal examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ yarn start
 
 ## Examples
 
-### [Flow](https://flow.org)
+### [Flow](https://flow.org) - static type checker
 
-- [Flow static type checker](flow)
+- [Flow simple](flow)
+- [Flow with Parcel Absolute Path Module Resolution](flow-with-absolute-module-resolution)
 
 ### [Node.js](https://nodejs.org/)
 
@@ -26,8 +27,9 @@ yarn start
 ### [React](https://reactjs.org)
 
 - [JavaScript](react)
-- [TypeScript & React](typescript-react)
 - [Reason React](reason-react)
+- [TypeScript & React](typescript-react)
+- [TypeScript & React with Parcel Tilde Path Module Resolution](typescript-react-with-tilde-module-resolution)
 - [create-react-app-parcel](https://github.com/sw-yx/create-react-app-parcel)
 
 ### [Preact](https://preactjs.com/)

--- a/flow-with-absolute-module-resolution/.flowconfig
+++ b/flow-with-absolute-module-resolution/.flowconfig
@@ -1,0 +1,2 @@
+[options]
+module.name_mapper='^\/\(.*\)$' -> '<PROJECT_ROOT>/src/\1'

--- a/flow-with-absolute-module-resolution/README.md
+++ b/flow-with-absolute-module-resolution/README.md
@@ -1,8 +1,12 @@
-# Parcel with Flow
+# Parcel Absolute Module Resolution with Flow
 
 Parcel supports using Flow types out of the box.
 
 In this example we use the `// @flow` pragma at the top of each JS file to have it's types checked.
+
+We also demonstrate the use of [Parcel Absolute Module Resolution](https://parceljs.org/module_resolution.html#flow-with-absolute-or-tilde-resolution) - see the imports in `index.js` as well as `index.html`. Imports are resolved from the **project root**, which is defined as the Parcel entrypoint, which in this case is `src/index.html`, so every `/` import is resolved from the `src/` folder.
+
+For Flow to understand where `/index.js` is actually imported from we need to account for this difference. `module.name_mapper` is a `.flowconfig` option which remaps the imports for Flow. In this instance, `/index.js` must become `src/index.js`.
 
 To run Flow, either install it as an editor indtegration, or run either `yarn run flow` or `npm run flow`.
 
@@ -27,7 +31,8 @@ Cannot assign banana.color to bananaColor because string [1] is incompatible wit
 
 ## Further Reading:
 
+- [Parcel Absolute Module Resolution](https://parceljs.org/module_resolution.html)
+- [Flow with Parcel Absolute or Tilde Module Resolution](https://parceljs.org/module_resolution.html#flow-with-absolute-or-tilde-resolution)
 - [Flow](https://flow.org/)
+- [Flow `module.name_mapper`](https://flow.org/en/docs/config/options/#toc-module-name-mapper-regex-string)
 - [Flow Editor Setup](https://flow.org/en/docs/editors/)
-
-For an example supporting Parcel's Absolute Module Resolution, see [Parcel Absolute Module Resolution with Flow](https://github.com/parcel-bundler/examples/tree/master/flow-with-absolute-module-resolution).

--- a/flow-with-absolute-module-resolution/package.json
+++ b/flow-with-absolute-module-resolution/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "parcel-flow",
-  "description": "Parcel & Flow simple example",
+  "name": "parcel-flow-absolute-module-resolution",
+  "description": "Parcel Absolute Module Resolution with Flow",
   "version": "1.0.0",
   "main": "src/index.js",
   "license": "MIT",

--- a/flow-with-absolute-module-resolution/package.json
+++ b/flow-with-absolute-module-resolution/package.json
@@ -2,7 +2,7 @@
   "name": "parcel-flow-absolute-module-resolution",
   "description": "Parcel Absolute Module Resolution with Flow",
   "version": "1.0.0",
-  "main": "src/index.js",
+  "main": "src/index.html",
   "license": "MIT",
   "scripts": {
     "start": "parcel src/index.html --open",

--- a/flow-with-absolute-module-resolution/src/fruits/apple.js
+++ b/flow-with-absolute-module-resolution/src/fruits/apple.js
@@ -1,0 +1,6 @@
+// @flow
+
+export default {
+  color: "red",
+  ripe: true,
+};

--- a/flow-with-absolute-module-resolution/src/fruits/banana.js
+++ b/flow-with-absolute-module-resolution/src/fruits/banana.js
@@ -1,0 +1,6 @@
+// @flow
+
+export default {
+  color: "green",
+  ripe: false,
+};

--- a/flow-with-absolute-module-resolution/src/index.html
+++ b/flow-with-absolute-module-resolution/src/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/flow-with-absolute-module-resolution/src/index.html
+++ b/flow-with-absolute-module-resolution/src/index.html
@@ -1,14 +1,14 @@
 <html>
 
 <head>
-  <title>Parcel with Flow</title>
+  <title>Parcel Absolute Module Resolution with Flow</title>
   <meta charset="UTF-8" />
 </head>
 
 <body>
   <div id="app"></div>
 
-  <script src="./main.js"></script>
+  <script src="/main.js"></script>
 </body>
 
 </html>

--- a/flow-with-absolute-module-resolution/src/main.js
+++ b/flow-with-absolute-module-resolution/src/main.js
@@ -7,4 +7,4 @@ let ripeApple: boolean = apple.ripe;
 let bananaColor: boolean = banana.color;
 
 console.log("is the apple ripe?", ripeApple);
-console.log("what is the banana's color", bananaColor);
+console.log("what is the banana's color?", bananaColor);

--- a/flow/.flowconfig
+++ b/flow/.flowconfig
@@ -1,2 +1,0 @@
-[options]
-module.name_mapper='^\/\(.*\)$' -> '<PROJECT_ROOT>/src/\1'

--- a/flow/package.json
+++ b/flow/package.json
@@ -2,7 +2,7 @@
   "name": "parcel-flow",
   "description": "Parcel & Flow simple example",
   "version": "1.0.0",
-  "main": "src/index.js",
+  "main": "src/index.html",
   "license": "MIT",
   "scripts": {
     "start": "parcel src/index.html --open",

--- a/flow/src/index.html
+++ b/flow/src/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>

--- a/flow/src/main.js
+++ b/flow/src/main.js
@@ -1,0 +1,10 @@
+// @flow
+
+import apple from "./fruits/apple";
+import banana from "./fruits/banana";
+
+let ripeApple: boolean = apple.ripe;
+let bananaColor: boolean = banana.color;
+
+console.log("is the apple ripe?", ripeApple);
+console.log("what is the banana's color?", bananaColor);

--- a/hyperapp/README.md
+++ b/hyperapp/README.md
@@ -2,9 +2,6 @@
 
 Since Parcel has out of the box support for JSX there's no added config required for Hyperapp to work
 
-The only special thing in this example is the use of Parcel's Absolute Path Module Resolution to avoid relative imports.
-
 ## Further Reading
 
 - [Hyperapp docs](https://github.com/jorgebucaran/hyperapp#hyperapp)
-- [Parcel's Absolute Path Module Resolution](https://parceljs.org/module_resolution.html)

--- a/hyperapp/src/index.html
+++ b/hyperapp/src/index.html
@@ -1,9 +1,13 @@
+<!DOCTYPE html>
 <html>
-  <head>
-    <title>Parcel Hyperapp Example</title>
-    <meta charset="UTF-8"/>
-  </head>
-  <body>
-    <script src="./main.js"></script>
-  </body>
+
+<head>
+  <title>Parcel Hyperapp Example</title>
+  <meta charset="UTF-8" />
+</head>
+
+<body>
+  <script src="./main.js"></script>
+</body>
+
 </html>

--- a/hyperapp/src/index.html
+++ b/hyperapp/src/index.html
@@ -4,6 +4,6 @@
     <meta charset="UTF-8"/>
   </head>
   <body>
-    <script src="/main.js"></script>
+    <script src="./main.js"></script>
   </body>
 </html>

--- a/hyperapp/src/main.js
+++ b/hyperapp/src/main.js
@@ -1,5 +1,5 @@
 import { app } from 'hyperapp'
-import view from '/App'
+import view from './App'
 
 const state = {
   count: 0

--- a/preact/README.md
+++ b/preact/README.md
@@ -2,9 +2,6 @@
 
 Like React, Preact is supported out of the box.
 
-The only special thing in this example is the use of Parcel's Absolute Path Module Resolution to avoid relative imports.
-
 ## Further Reading
 
 - [Preact Docs](https://preactjs.com/)
-- [Parcel's Absolute Path Module Resolution](https://parceljs.org/module_resolution.html)

--- a/preact/package.json
+++ b/preact/package.json
@@ -2,7 +2,7 @@
   "name": "parcel-preact-example",
   "description": "Simple Preact example",
   "version": "1.0.0",
-  "main": "src/App.jsx",
+  "main": "src/index.html",
   "license": "MIT",
   "scripts": {
     "start": "parcel src/index.html --open",

--- a/preact/src/App.jsx
+++ b/preact/src/App.jsx
@@ -1,5 +1,5 @@
 import { h, Component } from 'preact'
-import '/App.css'
+import './App.css'
 
 export default class App extends Component {
   render() {

--- a/preact/src/index.html
+++ b/preact/src/index.html
@@ -1,11 +1,15 @@
+<!DOCTYPE html>
 <html>
-  <head>
-    <title>Parcel Preact Example</title>
-    <meta charset="UTF-8"/>
-  </head>
-  <body>
-    <div id="app"></div>
 
-    <script src="/main.js"></script>
-  </body>
+<head>
+  <title>Parcel Preact Example</title>
+  <meta charset="UTF-8" />
+</head>
+
+<body>
+  <div id="app"></div>
+
+  <script src="./main.js"></script>
+</body>
+
 </html>

--- a/react/README.md
+++ b/react/README.md
@@ -2,9 +2,6 @@
 
 Parcel supports React out of the box!
 
-The only special thing in this example is the use of Parcel's Absolute Path Module Resolution to avoid relative imports.
-
 ## Further Reading
 
 - [React Docs](https://reactjs.org/)
-- [Parcel's Absolute Path Module Resolution](https://parceljs.org/module_resolution.html)

--- a/react/package.json
+++ b/react/package.json
@@ -2,7 +2,7 @@
   "name": "parcel-react-example",
   "description": "Simple React example",
   "version": "1.0.0",
-  "main": "src/App.jsx",
+  "main": "src/index.html",
   "license": "MIT",
   "scripts": {
     "start": "parcel src/index.html --open",

--- a/react/src/App.jsx
+++ b/react/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import '/App.css'
+import './App.css'
 
 export default class App extends Component {
   render() {

--- a/react/src/index.html
+++ b/react/src/index.html
@@ -1,11 +1,15 @@
+<!DOCTYPE html>
 <html>
-  <head>
-    <title>Parcel React Example</title>
-    <meta charset="UTF-8"/>
-  </head>
-  <body>
-    <div id="app"></div>
 
-    <script src="/main.js"></script>
-  </body>
+<head>
+  <title>Parcel React Example</title>
+  <meta charset="UTF-8" />
+</head>
+
+<body>
+  <div id="app"></div>
+
+  <script src="./main.js"></script>
+</body>
+
 </html>

--- a/react/src/main.js
+++ b/react/src/main.js
@@ -1,5 +1,5 @@
 import React from 'react'
 import { render } from 'react-dom'
-import App from '/App'
+import App from './App'
 
 render(<App />, document.getElementById('app'))

--- a/reason-react/README.md
+++ b/reason-react/README.md
@@ -1,0 +1,10 @@
+# Parcel Reason React Example
+
+Parcel supports compiling Reason to JavaScript out of the box!
+
+## Further Reading
+
+- [ReasonML Docs](https://reasonml.github.io/)
+- [BuckleScript Docs](https://bucklescript.github.io/)
+- [ReasonReact Docs](https://reasonml.github.io/reason-react/)
+- [React Docs](https://reactjs.org/)

--- a/reason-react/package.json
+++ b/reason-react/package.json
@@ -2,7 +2,7 @@
   "name": "parcel-reason-react-example",
   "description": "ReasonReact & Parcel example",
   "version": "1.0.0",
-  "main": "src/Main.re",
+  "main": "src/Index.html",
   "license": "MIT",
   "scripts": {
     "start": "parcel src/Index.html --open",

--- a/reason-react/src/Index.html
+++ b/reason-react/src/Index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -7,7 +8,7 @@
 
 <body>
   <div id="app"></div>
-  <script src="/Main.re"></script>
+  <script src="./Main.re"></script>
 </body>
 
 </html>

--- a/typescript-react-with-tilde-module-resolution/README.md
+++ b/typescript-react-with-tilde-module-resolution/README.md
@@ -1,0 +1,34 @@
+# Parcel Tilde Module Resolution with TypeScript React Example
+
+Parcel supports TS out of the box!
+
+Much like Flow, the TS typechecker is unaware of any use of Parcel's Module Resolution methods. This means supporting Absolute Path imports is difficult (please share examples if you have any) at this time. Fortunately, we can achieve a similar result with Parcel's Tilde Path Module Resolution and the `tsconfig` `baseUrl` and `path` properties.
+
+Using the following `tsconfig` settings:
+
+```json
+  "baseUrl": ".",
+  "paths": {
+    "~*": ["src/*"]
+  }
+```
+
+we can import like this:
+
+```javascript
+// main.tsx
+import '~/App'
+```
+
+Parcel looks for `App` in the **package root** but falls back to the **project root** (defined as the entry point directory), which in this example is the `src/` folder.
+
+Meanwhile, TypeScript sees the `~` and performs a lookup in the `tsconfig.json` `paths` object and finds the `src/` folder.
+
+TypeScript support is ongoing. [Please see this issue for a collection of issues and updates](https://github.com/parcel-bundler/parcel/issues/1378)
+
+## Further Reading
+
+- [TypeScript docs](https://www.typescriptlang.org/docs/home.html)
+- [Parcel Module Resolution](https://parceljs.org/module_resolution.html)
+- [Parcel Tilde Path Module Resolution with TypeScript](https://parceljs.org/module_resolution.html#typescript-~-resolution)
+- [TypeScript Module Resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html)

--- a/typescript-react-with-tilde-module-resolution/package.json
+++ b/typescript-react-with-tilde-module-resolution/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "typescript-react-tilde-resolution",
+  "description": "Parcel TypeScript with Tilde Module Resolution",
+  "version": "1.0.0",
+  "main": "src/index.html",
+  "license": "MIT",
+  "scripts": {
+    "start": "parcel src/index.html --open",
+    "build": "parcel build src/index.html",
+    "type-check": "tsc --noEmit",
+    "type-check:watch": "tsc --noEmit --watch"
+  },
+  "dependencies": {
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0"
+  },
+  "devDependencies": {
+    "@types/react": "^16.4.18",
+    "@types/react-dom": "^16.0.9",
+    "parcel-bundler": "^1.10.3",
+    "typescript": "^3.1.3"
+  }
+}

--- a/typescript-react-with-tilde-module-resolution/src/App.css
+++ b/typescript-react-with-tilde-module-resolution/src/App.css
@@ -1,0 +1,25 @@
+html,
+body {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+body {
+  background: white;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+h1 {
+  font-weight: 300;
+}

--- a/typescript-react-with-tilde-module-resolution/src/App.tsx
+++ b/typescript-react-with-tilde-module-resolution/src/App.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react'
+import '~/App.css'
+
+export default class App extends React.Component<{}, {}> {
+  render() {
+    return (
+      <div>
+        <h1>Hello World from TypeScript! 📦 🚀</h1>
+      </div>
+    )
+  }
+}

--- a/typescript-react-with-tilde-module-resolution/src/index.html
+++ b/typescript-react-with-tilde-module-resolution/src/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Parcel Tilde Module Resolution with TypeScript React</title>
+    <meta charset="UTF-8" />
+</head>
+
+<body>
+    <div id="app"></div>
+    <script src="~/main.tsx"></script>
+</body>
+
+</html>

--- a/typescript-react-with-tilde-module-resolution/src/main.tsx
+++ b/typescript-react-with-tilde-module-resolution/src/main.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react'
+import { render } from 'react-dom'
+import App from '~/App'
+
+render(<App />, document.getElementById('app'))

--- a/typescript-react-with-tilde-module-resolution/tsconfig.json
+++ b/typescript-react-with-tilde-module-resolution/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "jsx": "react",
+    "baseUrl": ".",
+    "paths": {
+      "~*": ["src/*"]
+    },
+    "lib": ["dom", "es2015"]
+  }
+}

--- a/typescript-react/README.md
+++ b/typescript-react/README.md
@@ -2,32 +2,10 @@
 
 Parcel supports TS out of the box!
 
-Much like Flow, the TS typechecker is unaware of any use of Parcel's Module Resolution methods. This means supporting Absolute Path imports is difficult (please share examples if you have any) at this time. Fortunately, we can achieve a similar result with Parcel's Tilde Path Module Resolution and the `tsconfig` `baseUrl` and `path` properties.
-
-Using the following `tsconfig` settings:
-
-```json
-  "baseUrl": ".",
-  "paths": {
-    "~*": ["src/*"]
-  }
-```
-
-we can import like this:
-
-```javascript
-// main.tsx
-import '~/App'
-```
-
-Parcel looks for `App` in the **package root** but falls back to the **project root** (defined as the entry point directory), which in this example is the `src/` folder.
-
-Meanwhile, TypeScript sees the `~` and performs a lookup in the `tsconfig.json` `paths` object and finds the `src/` folder.
-
 TypeScript support is ongoing. [Please see this issue for a collection of issues and updates](https://github.com/parcel-bundler/parcel/issues/1378)
 
 ## Further Reading
 
-- [Parcel Module Resolution](https://parceljs.org/module_resolution.html)
+- [TypeScript docs](https://www.typescriptlang.org/docs/home.html)
 - [Parcel Tilde Path Module Resolution with TypeScript](https://parceljs.org/module_resolution.html#typescript-~-resolution)
-- [TypeScript Module Resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html)
+- [Parcel Tilde Module Resolution with TypeScript Example](https://github.com/parcel-bundler/examples/tree/master/typescript-react-with-tilde-module-resolution)

--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "typescript",
+  "name": "typescript-react",
+  "description": "Parcel TypeScript simple example",
   "version": "1.0.0",
-  "main": "src/App.tsx",
+  "main": "src/index.html",
   "license": "MIT",
   "scripts": {
     "start": "parcel src/index.html --open",
@@ -17,6 +18,6 @@
     "@types/react": "^16.4.18",
     "@types/react-dom": "^16.0.9",
     "parcel-bundler": "^1.10.3",
-    "typescript": "^3.1.3"
+    "typescript": "^3.1.4"
   }
 }

--- a/typescript-react/src/App.tsx
+++ b/typescript-react/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import '~/App.css'
+import './App.css'
 
 export default class App extends React.Component<{}, {}> {
   render() {

--- a/typescript-react/src/index.html
+++ b/typescript-react/src/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
 
 <head>
-    <title>Parcel TypeScript React Example</title>
+    <title>Parcel TypeScript React</title>
     <meta charset="UTF-8" />
 </head>
 
 <body>
     <div id="app"></div>
-    <script src="~/main.tsx"></script>
+    <script src="./main.tsx"></script>
 </body>
 
 </html>

--- a/typescript-react/src/main.tsx
+++ b/typescript-react/src/main.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
 import { render } from 'react-dom'
-import App from '~/App'
+import App from './App'
 
 render(<App />, document.getElementById('app'))

--- a/typescript-react/tsconfig.json
+++ b/typescript-react/tsconfig.json
@@ -4,10 +4,6 @@
     "module": "commonjs",
     "strict": true,
     "jsx": "react",
-    "baseUrl": ".",
-    "paths": {
-      "~*": ["src/*"]
-    },
     "lib": ["dom", "es2015"]
   }
 }

--- a/vue/README.md
+++ b/vue/README.md
@@ -2,14 +2,6 @@
 
 Like React, Vue is supported out of the box!
 
-Parcel Absolute Path Module Resolution is being used to import files without relative paths!
-
-```javascript
-// main.js
-import App from '/App.vue'
-```
-
 ## Further Reading
 
 - [Vue docs](https://vuejs.org/v2/guide/)
-- [Parcel Absolute Path Module Resolution](https://parceljs.org/module_resolution.html#absolute-paths)

--- a/vue/package.json
+++ b/vue/package.json
@@ -2,7 +2,7 @@
   "name": "parcel-vuejs-example",
   "description": "Simple Vue.js example",
   "version": "1.0.0",
-  "main": "src/App.vue",
+  "main": "src/index.html",
   "scripts": {
     "start": "parcel src/index.html --open",
     "build": "parcel build src/index.html"

--- a/vue/src/index.html
+++ b/vue/src/index.html
@@ -7,7 +7,7 @@
 
 <body>
   <div id="app"></div>
-  <script src="/main.js"></script>
+  <script src="./main.js"></script>
 </body>
 
 </html>

--- a/vue/src/main.js
+++ b/vue/src/main.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import App from '/App.vue'
+import App from './App.vue'
 
 new Vue({
   el: '#app',


### PR DESCRIPTION
* remove use of Parcel's Absolute/Tilde Path Module Resolution strategies in simple examples
* add specific Flow & Abs Path Module Resolution example
* add specific TS & Tilde Path Module Resolution example
* update readme

[EDIT]: this was initially written to enable the use of Codesandbox to inline and sync the examples here with the docs recipe page https://github.com/parcel-bundler/website/pull/288 - however despite that going through I think it's still valuable in simplifying the base examples